### PR TITLE
Add container name to runArgs in devcontainer.json

### DIFF
--- a/devcontainer.json
+++ b/devcontainer.json
@@ -18,7 +18,9 @@
     "runArgs": [
         "--gpus",
         "all",
-        "--shm-size=32gb"
+        "--shm-size=32gb",
+        "--name",
+        "${localEnv:USER}_${localWorkspaceFolderBasename}"
     ],
     "mounts": [
         "source=${env:HOME}/.ssh,target=/home/vscode/.ssh,readonly,type=bind"


### PR DESCRIPTION
Add container name to runArgs in devcontainer.json (username_name-of-workspace-folder). This makes running Docker containers more interpretable.